### PR TITLE
CFLAGS for 04-mqtt example to avoid 'region ram overflowed' error restored

### DIFF
--- a/examples/zolertia/tutorial/04-mqtt/Makefile
+++ b/examples/zolertia/tutorial/04-mqtt/Makefile
@@ -7,6 +7,10 @@ APPS += mqtt
 # Linker size optimization
 SMALL = 1
 
+# Override this due to RAM overflow
+CFLAGS += -DNBR_TABLE_CONF_MAX_NEIGHBORS=3
+CFLAGS += -DUIP_CONF_MAX_ROUTES=3
+
 CONTIKI_WITH_IPV6 = 1
 
 CONTIKI = ../../../..


### PR DESCRIPTION
Building contiki/examples/zolertia/tutorial/04-mqtt/mqtt-demo.c for z1 mote fails with error:

```
contiki/examples/zolertia/tutorial/04-mqtt [:35f76eb|✔] $ make
using saved target 'z1'
mkdir obj_z1
  CC        ../../../../apps/mqtt/mqtt.c
### Some lines ignored
  LD        mqtt-demo.z1
/opt/msp430-47/bin/../lib/gcc/msp430/4.7.0/../../../../msp430/bin/ld: mqtt-demo.z1 section `.bss' will not fit in region `ram'
/opt/msp430-47/bin/../lib/gcc/msp430/4.7.0/../../../../msp430/bin/ld: region `ram' overflowed by 790 bytes
collect2: error: ld returned 1 exit status
### Some lines ignored
```

But in older commits it used to work, the last time it worked was with commit 1875c0aad3b4670d4486140c7f00bb0f243a6290, from this commit to the next one the only relevant differences are some values added to CFLAGS on the Makefile. This lines were added in this patch and allowed to compile this example.
